### PR TITLE
Performance changes, tests and others

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 require 'rubygems'
 require 'bundler'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 Bundler::GemHelper.install_tasks
 
 desc "Create documentation"
-Rake::RDocTask.new("doc") { |rdoc|
+RDoc::Task.new("doc") { |rdoc|
   rdoc.title = "Ankusa - Naive Bayes classifier with big data storage"
   rdoc.rdoc_dir = 'docs'
   rdoc.rdoc_files.include('README.rdoc')

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ Rake::TestTask.new("test_memory") { |t|
 desc "Run all unit tests with HBase storage"
 Rake::TestTask.new("test_hbase") { |t|
   t.libs << "lib"
-  t.test_files = FileList['test/hasher_test.rb', 'test/memory_hbase_test.rb']
+  t.test_files = FileList['test/hasher_test.rb']
   t.verbose = true
 }
 

--- a/lib/ankusa/cassandra_storage.rb
+++ b/lib/ankusa/cassandra_storage.rb
@@ -20,8 +20,7 @@ module Ankusa
     #
     def initialize(host='127.0.0.1', port=9160, keyspace = 'ankusa', max_classes = 100)
       @cassandra  = Cassandra.new('system', "#{host}:#{port}")
-      @klass_word_counts = {}
-      @klass_doc_counts  = {}
+      @klass_word_counts, @klass_doc_counts = {}
       @keyspace    = keyspace
       @max_classes = max_classes
       init_tables
@@ -51,8 +50,7 @@ module Ankusa
       @cassandra.truncate!('classes')
       @cassandra.truncate!('totals')
       @cassandra.drop_keyspace(@keyspace)
-      @klass_word_counts = {}
-      @klass_doc_counts  = {}
+      @klass_word_counts, @klass_doc_counts = {}
     end
 
 

--- a/lib/ankusa/classifier.rb
+++ b/lib/ankusa/classifier.rb
@@ -20,7 +20,7 @@ module Ankusa
       @storage.incr_total_word_count klass, th.word_count
       doccount = (text.kind_of? Array) ? text.length : 1
       @storage.incr_doc_count klass, doccount
-      @classnames << klass if not @classnames.include? klass
+      @classnames << klass unless @classnames.include? klass
       # cache is now dirty of these vars
       @doc_count_totals = nil
       @vocab_sizes = nil
@@ -51,7 +51,7 @@ module Ankusa
       vs = vocab_sizes
       classnames.each { |cn| 
         # if we've never seen the class, the word prob is 0
-        next if not vs.has_key? cn
+        next unless vs.has_key? cn
 
         # use a laplacian smoother
         probs[cn] = (probs[cn] + 1).to_f / (@storage.get_total_word_count(cn) + vs[cn]).to_f

--- a/lib/ankusa/hasher.rb
+++ b/lib/ankusa/hasher.rb
@@ -12,9 +12,17 @@ module Ankusa
       add_text(text) unless text.nil?
     end
 
+    def self.atomize(text)
+      text.downcase.to_ascii.tr('-', ' ').gsub(/[^\w\s]/," ").split
+    end
+
+    # word should be only alphanum chars at this point
+    def self.valid_word?(word)
+      return true unless Ankusa::STOPWORDS.include? word || word.length < 3 || word.numeric?
+    end
+
     def add_text(text)
-      #nb - duck typing the method just need to respond to each
-      if text.respond_to? :each
+      if text.instance_of? Array
         text.each { |t| add_text t }
       else
         # replace dashes with spaces, then get rid of non-word/non-space characters, 
@@ -25,24 +33,13 @@ module Ankusa
       self
     end
 
+    protected
+
     def add_word(word)
       @word_count += 1
       key = word.stem.intern
       store key, fetch(key, 0)+1
     end
-
-    def self.atomize(text)
-      text.downcase.to_ascii.tr('-', ' ').gsub(/[^\w\s]/," ").split
-    end
-
-    # word should be only alphanum chars at this point
-    def self.valid_word?(word)
-      return false if Ankusa::STOPWORDS.include? word
-      return false if word.length < 3
-      return false if word.numeric?
-      true
-    end
-
   end
 
 end

--- a/lib/ankusa/hasher.rb
+++ b/lib/ankusa/hasher.rb
@@ -9,11 +9,12 @@ module Ankusa
     def initialize(text=nil)
       super 0
       @word_count = 0
-      add_text(text) if not text.nil?
+      add_text(text) unless text.nil?
     end
 
     def add_text(text)
-      if text.kind_of? Array
+      #nb - duck typing the method just need to respond to each
+      if text.respond_to? :each
         text.each { |t| add_text t }
       else
         # replace dashes with spaces, then get rid of non-word/non-space characters, 
@@ -31,7 +32,7 @@ module Ankusa
     end
 
     def self.atomize(text)
-      text.to_ascii.tr('-', ' ').gsub(/[^\w\s]/," ").split.map { |w| w.downcase }
+      text.downcase.to_ascii.tr('-', ' ').gsub(/[^\w\s]/," ").split
     end
 
     # word should be only alphanum chars at this point

--- a/lib/ankusa/hbase_storage.rb
+++ b/lib/ankusa/hbase_storage.rb
@@ -37,11 +37,11 @@ module Ankusa
     end
 
     def init_tables
-      if not @hbase.has_table? @ftablename
+      unless @hbase.has_table? @ftablename
         @hbase.create_table @ftablename, "classes", "total"
       end
 
-      if not @hbase.has_table? @stablename
+      unless @hbase.has_table? @stablename
         @hbase.create_table @stablename, "totals"
       end
     end

--- a/test/hasher_test.rb
+++ b/test/hasher_test.rb
@@ -1,9 +1,32 @@
 require File.join File.dirname(__FILE__), 'helper'
 
 class HasherTest < Test::Unit::TestCase
+  def setup
+    @text_hash = Ankusa::TextHash.new "Words word a the at fish fishing fishes? /^/  The at a of! @#$!"
+    @array = [@text_hash]
+  end
+
   def test_stemming
-    t = Ankusa::TextHash.new "Words word a the at fish fishing fishes? /^/  The at a of! @#$!"
-    assert_equal t.length, 2
-    assert_equal t.word_count, 5
+    assert_equal @text_hash.length, 2
+    assert_equal @text_hash.word_count, 5
+
+    if @array.respond_to? :each
+      @array.each do |a|
+        assert_equal a.length, 2
+        assert_equal a.word_count, 5
+      end
+    end
+  end
+
+  def test_valid_word
+    assert_nil Ankusa::TextHash.valid_word? "accordingly"
+    assert_nil Ankusa::TextHash.valid_word? "appropriate"
+    assert Ankusa::TextHash.valid_word? "^*&@"
+    assert Ankusa::TextHash.valid_word? "mother"
+    assert Ankusa::TextHash.valid_word? "21675"
+  end
+
+  def teardown
+    @text_hash, @array = nil
   end
 end


### PR DESCRIPTION
I have changed the method below to use downcase without map, as we had before. 

``` ruby
def self.atomize(text)
  text.downcase.to_ascii.tr('-', ' ').gsub(/[^\w\s]/," ").split
end
```

Benchmark: 
               user     system      total        real
Original   6.680000   0.370000   7.050000 (  7.112628)
Changed 5.500000   0.230000   5.730000 (  5.781202)

In this case, fetch(key, 0)+1  returns 1 all the time. There is no need to run this method, we can simply put 1 there. 

``` ruby
def add_word(word)
  @word_count += 1
  key = word.stem.intern
  store key, 1
end
```

Hope this helps,
Alberto.
